### PR TITLE
Allow use with Node versions higher than 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write && prettier --config .prettierrc 'tests/**/*.ts' --write"
   },
   "engines": {
-    "node": "16"
+    "node": ">=16"
   },
   "keywords": [
     "json",


### PR DESCRIPTION
Yarn throws an error if schema-infer is installed on Node 18 otherwise