### PR TITLE
Use /usr/bin/env node for shebang

### DIFF
--- a/cli/schema-infer.js
+++ b/cli/schema-infer.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env/node
+#!/usr/bin/env node
 
 const { readFileSync } = require("fs");
 const yargs = require("yargs");


### PR DESCRIPTION
Using `#!/usr/bin/env/node` means the cli script will fail if `node` isn't installed exactly at that path. You'll get this error when trying to run the command:

```shell
➜ npx schema-infer
sh: ~/project/node_modules/.bin/schema-infer: /usr/bin/env/node: bad interpreter: Not a directory
```

Probably what you wanted here was `#!/usr/bin/env node` which uses the `env` command to execute `node` in the user's environment.